### PR TITLE
fix: systemd service failure

### DIFF
--- a/nix/module.nix
+++ b/nix/module.nix
@@ -24,6 +24,7 @@ in {
           ExecStart = "${config.services.blctl.package}/bin/blctld";
 	      };
         wantedBy = [ "multi-user.target" ];
+        after = [ "multi-user.target" ];
       };
     };
   };

--- a/nix/package.nix
+++ b/nix/package.nix
@@ -11,8 +11,8 @@ in
     src = pkgs.fetchFromGitHub {
       owner = "imxela";
       repo = "blctl";
-      rev = "af4124f9ac0cb247c8b90791b0acfdb59c55d7ca";
-      sha256 = "sha256-9yz+O323ZMTdv3E0kzPfjHUZM4nokdK3PqoBsjwtwJQ=";
+      rev = "cdc88e6ab1fb33ffd0e1f3c6f4d91c1eba61419f";
+      sha256 = "sha256-S0VAuGF2KzrlX/NQ/S1I1+n4Y9CoX1QxXo0VZ1HY380=";
     };
 
     cargoLock = {

--- a/service-configs/systemd/blctl.service
+++ b/service-configs/systemd/blctl.service
@@ -1,5 +1,6 @@
 [Unit]
 Description=A minimal backlight control daemon for Linux
+After=multi-user.target
 
 [Service]
 ExecStart=/usr/sbin/blctld


### PR DESCRIPTION
Fixes an issue with `blctl`'s systemd service failing to start due to `/sys/class/backlight/<backlight-device>` not yet existing.